### PR TITLE
Fix ArgoCD self-management sync failures with Replace=true

### DIFF
--- a/clusters/portcullis/infrastructure/argocd.yaml
+++ b/clusters/portcullis/infrastructure/argocd.yaml
@@ -31,6 +31,7 @@ spec:
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true  # Required for CRDs
+      - Replace=true  # Allow replacing resources with immutable field conflicts
     retry:
       limit: 5
       backoff:


### PR DESCRIPTION
## Problem

ArgoCD self-management application is failing to sync with immutable field errors:

```
Deployment.apps "argocd-server" is invalid: spec.selector: Invalid value: field is immutable
StatefulSet.apps "argocd-application-controller" is invalid: spec: Forbidden: updates to statefulset spec...
```

## Root Cause

The manually installed ArgoCD has different label selectors than what the Helm chart expects:

**Manual Installation:**
```json
{
  "app.kubernetes.io/name": "argocd-server"
}
```

**Helm Chart:**
```json
{
  "app.kubernetes.io/name": "argocd-server",
  "app.kubernetes.io/instance": "argocd"
}
```

Kubernetes doesn't allow modifying immutable fields like `spec.selector` on Deployments and StatefulSets.

## Solution

Added `Replace=true` to the sync options in `clusters/portcullis/infrastructure/argocd.yaml`. This tells ArgoCD to delete and recreate resources when updates would violate immutability constraints.

## What Changed

```yaml
syncOptions:
  - CreateNamespace=true
  - ServerSideApply=true
  - Replace=true  # NEW: Allow replacing resources with immutable field conflicts
```

## Impact

- **Brief downtime**: ArgoCD components will be deleted and recreated
- **Scope**: Only affects resources with immutable field conflicts (Deployments/StatefulSets)
- **Safety**: ConfigMaps, Secrets, RBAC, and other resources update normally without replacement
- **Recovery**: ArgoCD will recreate itself and should become healthy within 1-2 minutes

## Verification Steps

After merging and syncing:

1. Watch the sync progress:
   ```bash
   kubectl get application argocd -n argocd -w
   ```

2. Monitor pod recreation:
   ```bash
   kubectl get pods -n argocd -w
   ```

3. Verify all resources reach Synced status:
   ```bash
   kubectl describe application argocd -n argocd
   ```

4. Check ArgoCD UI accessibility (may have brief interruption during pod restart)

## GitHub Issue

Resolves [#18](https://github.com/osowski/homelab-argocd/issues/18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)