### PR TITLE
Allow Certificate and IngressRoute resources in workloads AppProject

### DIFF
--- a/bootstrap/templates/argocd-projects.yaml
+++ b/bootstrap/templates/argocd-projects.yaml
@@ -115,3 +115,7 @@ spec:
       kind: KsqlDB
     - group: platform.confluent.io
       kind: ControlCenter
+    - group: cert-manager.io
+      kind: Certificate
+    - group: traefik.io
+      kind: IngressRoute


### PR DESCRIPTION
## Summary

Updates the **workloads AppProject** to allow creation of `Certificate` and `IngressRoute` resources, enabling workloads to expose services externally with TLS support.

This is a **prerequisite for PR #37** (controlcenter-ingress).

## Problem

The workloads AppProject currently does not include:
- `cert-manager.io/Certificate` in namespaceResourceWhitelist
- `traefik.io/IngressRoute` in namespaceResourceWhitelist

Without these permissions, workloads that need external access with TLS (like controlcenter-ingress) cannot create the necessary resources and will fail to sync.

## Changes

**File:** `bootstrap/templates/argocd-projects.yaml`

Added to workloads AppProject `namespaceResourceWhitelist`:
```yaml
- group: cert-manager.io
  kind: Certificate
- group: traefik.io
  kind: IngressRoute
```

## Rationale

### Certificate Resources
- **Namespace-scoped:** Certificates are namespace-scoped resources (safe for workloads)
- **TLS requirement:** Workloads exposing external endpoints need TLS certificates
- **Least privilege:** Only allows Certificate kind, not other cert-manager resources

### IngressRoute Resources
- **Namespace-scoped:** IngressRoutes are namespace-scoped (safe for workloads)
- **Traefik routing:** Workloads need to define routing rules for external access
- **Follows pattern:** Infrastructure already uses IngressRoute (e.g., argocd-ingress)
- **Least privilege:** Only allows IngressRoute, not other Traefik resources

## Use Case

**Example:** `controlcenter-ingress` workload needs to:
1. Create a `Certificate` resource for TLS (`controlcenter-tls` in `confluent` namespace)
2. Create an `IngressRoute` resource for routing (`controlcenter` in `confluent` namespace)

Without this change, the ArgoCD Application will fail with permission errors.

## Security Considerations

✅ **Namespace-scoped only** - No cluster-wide permissions granted  
✅ **Specific resource types** - Only Certificate and IngressRoute, not wildcard  
✅ **Least privilege** - Workloads can only create what they need  
✅ **Consistent with pattern** - Infrastructure project already uses these resources  

## Testing

### Validation
✅ YAML syntax valid
✅ Follows existing AppProject structure
✅ Only adds namespace-scoped resources

### Post-Merge Testing
After this PR is merged and bootstrap is re-synced:

1. **Verify AppProject updated:**
   ```bash
   kubectl get appproject -n argocd workloads -o yaml
   ```

2. **Test with controlcenter-ingress (PR #37):**
   ```bash
   # After PR #37 is merged
   kubectl get application -n argocd controlcenter-ingress
   kubectl get certificate -n confluent controlcenter-tls
   kubectl get ingressroute -n confluent controlcenter
   ```

## Impact

### Who is affected?
- **Existing deployments:** No impact (only adds permissions, doesn't change existing behavior)
- **New deployments:** Enables workloads to create Certificate and IngressRoute resources
- **PR #37:** Unblocks controlcenter-ingress deployment

### Rollout
1. Merge this PR first
2. Bootstrap Application will auto-sync and update workloads AppProject
3. Then merge PR #37 (controlcenter-ingress)

## Related

- **Blocks:** PR #37 (controlcenter-ingress)
- **Related Issue:** #30 (Control Center external access)
- **Pattern Reference:** `infrastructure/argocd-ingress/` (uses same resource types)

## Checklist

- [x] Updated workloads AppProject with Certificate permission
- [x] Updated workloads AppProject with IngressRoute permission
- [x] Maintained namespace-scoped permissions only
- [x] Followed least privilege principle
- [x] No breaking changes to existing deployments

---
🤖 Generated with Claude Code