### PR TITLE
Fix Grafana crashloop caused by duplicate default datasources

### DIFF
--- a/infrastructure/kube-prometheus-stack/base/values.yaml
+++ b/infrastructure/kube-prometheus-stack/base/values.yaml
@@ -75,16 +75,8 @@ grafana:
   ingress:
     enabled: false
 
-  # Default datasources (Prometheus)
-  datasources:
-    datasources.yaml:
-      apiVersion: 1
-      datasources:
-        - name: Prometheus
-          type: prometheus
-          url: http://kube-prometheus-stack-prometheus:9090
-          access: proxy
-          isDefault: true
+  # Datasources configured by chart defaults (prometheus.datasources.defaultDatasourceEnabled: true)
+  # No need to override - chart creates Prometheus datasource automatically
 
   # Dashboard providers
   dashboardProviders:


### PR DESCRIPTION
## Problem

Grafana pods are **crashlooping** with the error:
```
only one datasource per organization can be marked as default
```

This is a **high severity issue** causing Grafana to be completely unavailable.

## Root Cause Analysis

The kube-prometheus-stack Helm chart creates **two separate Prometheus datasources**, both marked as default:

### 1. Chart's Built-in Datasource (Default Behavior)
The chart automatically creates a Prometheus datasource:
```yaml
prometheus:
  datasources:
    defaultDatasourceEnabled: true  # Enabled by default
    isDefaultDatasource: true
    name: Prometheus
```

### 2. Our Duplicate Custom Datasource
We unnecessarily overrode this with our own configuration:
```yaml
grafana:
  datasources:
    datasources.yaml:
      apiVersion: 1
      datasources:
        - name: Prometheus
          type: prometheus
          url: http://kube-prometheus-stack-prometheus:9090
          isDefault: true  # Duplicate!
```

### Result
**Two datasources** are created, both marked as `isDefault: true`, violating Grafana's constraint.

## Solution

**Remove our custom datasource configuration** and use the chart's default.

This is the **simpler and more maintainable** approach:
- ✅ Less code to maintain
- ✅ Follows chart best practices (use defaults unless customization needed)
- ✅ Eliminates configuration duplication
- ✅ No functional difference (chart default provides same configuration)

## Changes

**File:** `infrastructure/kube-prometheus-stack/base/values.yaml`

```diff
   # Disable ingress (configured per-cluster in overlay)
   ingress:
     enabled: false
 
-  # Default datasources (Prometheus)
-  datasources:
-    datasources.yaml:
-      apiVersion: 1
-      datasources:
-        - name: Prometheus
-          type: prometheus
-          url: http://kube-prometheus-stack-prometheus:9090
-          access: proxy
-          isDefault: true
+  # Datasources configured by chart defaults (prometheus.datasources.defaultDatasourceEnabled: true)
+  # No need to override - chart creates Prometheus datasource automatically
 
   # Dashboard providers
   dashboardProviders:
```

**Net change:** -10 lines, +2 lines (simplified!)

## Why This Approach?

### Alternative Considered
We could have disabled the chart's default and kept our custom configuration:
```yaml
prometheus:
  datasources:
    defaultDatasourceEnabled: false
```

### Why We Chose to Remove Ours Instead
1. **Simpler** - Less configuration to maintain
2. **Standard** - Uses chart defaults (less likely to break on upgrades)
3. **No benefit** - Our custom config was identical to the chart's default
4. **Best practice** - Only override when you need different behavior

## Impact

### Before Fix
- ❌ Grafana pods crashlooping
- ❌ Grafana UI unavailable
- ❌ No monitoring dashboards accessible
- ❌ Error: "only one datasource per organization can be marked as default"

### After Fix
- ✅ Grafana pods start successfully
- ✅ Single default Prometheus datasource (via chart default)
- ✅ Grafana UI accessible
- ✅ All monitoring dashboards functional
- ✅ Simpler configuration (8 fewer lines)

### Configuration Comparison

**Chart's default datasource** (what we'll use):
- Name: `Prometheus`
- URL: Auto-configured to Prometheus service
- Type: `prometheus`
- Default: `true`

**Our removed datasource** (was duplicate):
- Name: `Prometheus`
- URL: `http://kube-prometheus-stack-prometheus:9090` (same as chart default)
- Type: `prometheus`
- Default: `true`

**Result:** Identical functionality, simpler code.

## Testing

### Verify Fix
After merging and ArgoCD sync:

```bash
# Wait for Grafana to restart
kubectl rollout status deployment -n monitoring kube-prometheus-stack-grafana

# Check Grafana pods are running
kubectl get pods -n monitoring -l app.kubernetes.io/name=grafana

# Verify datasources
kubectl port-forward -n monitoring svc/kube-prometheus-stack-grafana 3000:80 &

# Login to Grafana (http://localhost:3000)
# Check: Configuration > Data sources
# Expected: Single "Prometheus" datasource marked as default
```

### Validation
```bash
# Check logs for errors (should be clean)
kubectl logs -n monitoring -l app.kubernetes.io/name=grafana

# Verify Prometheus datasource works
# In Grafana: Explore > Select Prometheus > Run query: up
```

## Security & Risk Assessment

**Risk Level:** Low
- Configuration simplification (removing duplicate)
- No new resources created
- Uses chart's tested defaults
- No functional behavior change

**Affected Clusters:** All (portcullis, artoo)

**Rollback:** Revert this commit if issues occur (unlikely)

## References

### Related Issues
- **Fixes:** #39

### External References
- [kube-prometheus-stack Issue #2251](https://github.com/prometheus-community/helm-charts/issues/2251) - Additional datasources not added correctly
- [kube-prometheus-stack Issue #5232](https://github.com/prometheus-community/helm-charts/issues/5232) - No default dashboard or datasource  
- [Grafana Prometheus datasource configuration](https://grafana.com/docs/grafana/latest/datasources/prometheus/configure/)

## Checklist

- [x] Root cause identified and documented
- [x] Fix implemented (remove duplicate datasource config)
- [x] Simpler solution chosen over complex workaround
- [x] Testing plan documented
- [x] Impact assessment completed
- [x] No breaking changes
- [x] Issue #39 linked

---
🤖 Generated with Claude Code