### PR TITLE
fix: Add Issuer and MutatingWebhookConfiguration to workloads RBAC (#45)

### DIFF
--- a/bootstrap/templates/argocd-projects.yaml
+++ b/bootstrap/templates/argocd-projects.yaml
@@ -60,6 +60,8 @@ spec:
       kind: CustomResourceDefinition
     - group: admissionregistration.k8s.io
       kind: ValidatingWebhookConfiguration
+    - group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
     - group: rbac.authorization.k8s.io
       kind: ClusterRole
     - group: rbac.authorization.k8s.io
@@ -117,6 +119,8 @@ spec:
       kind: ControlCenter
     - group: cert-manager.io
       kind: Certificate
+    - group: cert-manager.io
+      kind: Issuer
     - group: traefik.io
       kind: IngressRoute
     - group: flink.apache.org


### PR DESCRIPTION
## Summary

Fixes Issue #45 by adding missing resource permissions to the workloads project RBAC, allowing Flink operators and other workloads to create required cluster-scoped and namespace-scoped resources.

## Problem

Flink Kubernetes Operator and CMF operator deployments fail with permission errors because the workloads project lacks permissions for:
1. **MutatingWebhookConfiguration** (cluster-scoped)
2. **Issuer** (namespace-scoped)

## Changes

### Cluster-scoped Resources
Added to `clusterResourceWhitelist`:
```yaml
- group: admissionregistration.k8s.io
  kind: MutatingWebhookConfiguration
```

**Purpose**: Flink Kubernetes Operator creates mutating admission webhooks for validating and mutating FlinkDeployment resources.

### Namespace-scoped Resources
Added to `namespaceResourceWhitelist`:
```yaml
- group: cert-manager.io
  kind: Issuer
```

**Purpose**: Allows workloads to create namespace-scoped certificate issuers for TLS management.

## File Changed

- `bootstrap/templates/argocd-projects.yaml`

## Why These Permissions?

### MutatingWebhookConfiguration
- Flink Kubernetes Operator registers a MutatingWebhookConfiguration on startup
- Used for admission control of Flink custom resources
- Required for operator functionality
- Complements existing `ValidatingWebhookConfiguration` permission

### Issuer
- Namespace-scoped alternative to ClusterIssuer
- Allows workloads to manage their own certificate issuers
- Complements existing `Certificate` permission (Issue #30)
- Provides more granular TLS certificate management

## Security Considerations

Both resource types are appropriate for the workloads project:

✅ **MutatingWebhookConfiguration** 
- Cluster-scoped but namespace-limited via webhook selectors
- Operators need this for custom resource validation
- Already allows ValidatingWebhookConfiguration

✅ **Issuer**
- Namespace-scoped resource only
- Does not grant cluster-wide certificate authority
- Limited to issuer's namespace

## Testing Checklist

After merge, verify on portcullis and artoo clusters:

- [ ] Bootstrap application syncs successfully
- [ ] Flink Kubernetes Operator application syncs without permission errors
- [ ] CMF operator application syncs without permission errors
- [ ] Webhook created: `kubectl get mutatingwebhookconfigurations | grep flink`
- [ ] No RBAC errors in ArgoCD application status
- [ ] Operators are healthy: `kubectl get pods -n confluent -l app.kubernetes.io/name=flink-kubernetes-operator`

## Related Issues

- Fixes #45 - RBAC permission gap discovered during Flink deployment
- Related to #30 - Similar RBAC enhancement for Certificate resources
- Related to #26 - Flink deployment that exposed this requirement

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)