### PR TITLE
fix: Ignore CRD additionalPrinterColumns priority drift in Flink operator (#48)

### DIFF
--- a/clusters/artoo/workloads/flink-kubernetes-operator.yaml
+++ b/clusters/artoo/workloads/flink-kubernetes-operator.yaml
@@ -23,6 +23,11 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: confluent
+  ignoreDifferences:
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      jqPathExpressions:
+        - .spec.versions[].additionalPrinterColumns[].priority
   syncPolicy:
     automated:
       prune: true

--- a/clusters/portcullis/workloads/flink-kubernetes-operator.yaml
+++ b/clusters/portcullis/workloads/flink-kubernetes-operator.yaml
@@ -23,6 +23,11 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: confluent
+  ignoreDifferences:
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      jqPathExpressions:
+        - .spec.versions[].additionalPrinterColumns[].priority
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## Summary

Fixes Issue #48 by adding `ignoreDifferences` configuration to flink-kubernetes-operator Applications, eliminating false "OutOfSync" status caused by CRD field drift.

## Problem

The flink-kubernetes-operator Application constantly shows as "OutOfSync" in ArgoCD due to differences in the CustomResourceDefinition (CRD) `additionalPrinterColumns[].priority` field.

**Symptom:**
- ArgoCD perpetually detects drift in Flink CRDs
- Application shows "OutOfSync" despite no functional changes
- Sync operations don't resolve the issue (field reverts)

**Root Cause:**
1. Flink operator Helm chart creates CRDs with `additionalPrinterColumns`
2. Helm chart may specify or omit `priority` values
3. Kubernetes API server applies its own defaults during CRD persistence
4. ArgoCD detects this as drift from Git-defined state

## Solution

Added `ignoreDifferences` configuration to both cluster Applications:

```yaml
ignoreDifferences:
  - group: apiextensions.k8s.io
    kind: CustomResourceDefinition
    jqPathExpressions:
      - .spec.versions[].additionalPrinterColumns[].priority
```

### Why jqPathExpressions?

CRDs contain nested arrays:
- `.spec.versions[]` - Multiple CRD versions
- `.additionalPrinterColumns[]` - Multiple columns per version

`jqPathExpressions` with `[]` syntax matches all array elements, regardless of indices or counts.

## Files Changed

- `clusters/portcullis/workloads/flink-kubernetes-operator.yaml` - Added ignoreDifferences
- `clusters/artoo/workloads/flink-kubernetes-operator.yaml` - Added ignoreDifferences

## Impact

✅ **Eliminates false drift** - No more "OutOfSync" for cosmetic field differences  
✅ **Reduces UI noise** - ArgoCD shows accurate sync status  
✅ **No functional impact** - Priority field only affects kubectl column ordering  
✅ **Allows API defaults** - API server can inject defaults without triggering sync  

## Field Context: What is priority?

The `priority` field in `additionalPrinterColumns` controls column ordering in kubectl output:

```bash
kubectl get flinkdeployment
# Columns appear in priority order (0 = highest priority)
```

**Values:**
- `0` - Always shown (highest priority)
- `1+` - May be hidden if terminal width is limited
- Omitted - Kubernetes applies default based on column position

This is purely cosmetic and doesn't affect:
- Operator functionality
- Resource behavior
- API interactions
- Actual data stored

## Testing

After merge, verify on portcullis and artoo:

### Sync Status
```bash
# Should show "Synced" not "OutOfSync"
kubectl get application flink-kubernetes-operator -n argocd -o jsonpath='{.status.sync.status}'
```

### CRD Still Exists
```bash
# Verify CRDs are present and functional
kubectl get crd | grep flink
kubectl get flinkdeployment -A
```

### No Impact on Operator
```bash
# Operator should remain healthy
kubectl get pods -n confluent -l app.kubernetes.io/name=flink-kubernetes-operator
```

## Related Issues

- Fixes #48 - CRD drift causing false OutOfSync status
- Related to #26 - Original Flink deployment
- Related to #45 - RBAC permissions for Flink operators

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)