### PR TITLE
Switch Traefik from Deployment to DaemonSet

### DIFF
--- a/infrastructure/traefik/base/values.yaml
+++ b/infrastructure/traefik/base/values.yaml
@@ -1,3 +1,5 @@
+deployment:
+  kind: DaemonSet
 image:
   repository: traefik
   pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary

- Adds `deployment.kind: DaemonSet` to the Traefik base Helm values
- All other settings (NodePort, ports, nodeSelector, tolerations, providers) unchanged

## Test plan

- [ ] Verify Traefik pods run as DaemonSet: `kubectl get daemonset -n ingress`
- [ ] Confirm existing ingresses still resolve (ArgoCD, Grafana, Prometheus, etc.)

Resolves [#51](https://github.com/osowski/homelab-argocd/issues/51)

🤖 Generated with [Claude Code](https://claude.com/claude-code)